### PR TITLE
Remove damaged tile references

### DIFF
--- a/coaster/src/main/java/uq/deco2800/coaster/game/tiles/TileInfo.java
+++ b/coaster/src/main/java/uq/deco2800/coaster/game/tiles/TileInfo.java
@@ -46,20 +46,20 @@ public abstract class TileInfo {
 	public static void registerTiles() {
 
 		registerTile((new TileSolid(Tiles.DIRT)).setDisplayName("Dirt").setDefaultFilename("dirt.png")
-				.setNaturalSurface(true).setDestructible(true).setDamagedTile(Tiles.DIRT_DAMAGED)
+				.setNaturalSurface(true).setDestructible(true).setDamagedTile(Tiles.DIRT)
 				.setBackgroundTile(Tiles.DIRT_BACKGROUND));
 		registerTile((new TileSolid(Tiles.DIRT_DAMAGED)).setDisplayName("Dirt (Damaged)").setDefaultFilename("dirt-damaged.png")
-				.setNaturalSurface(true).setDestructible(true).setDamagedTile(Tiles.DIRT_DAMAGED)
+				.setNaturalSurface(true).setDestructible(true).setDamagedTile(Tiles.DIRT)
 				.setBackgroundTile(Tiles.DIRT_BACKGROUND));
 		registerTile((new TileScenery(Tiles.DIRT_BACKGROUND)).setDisplayName("Dirt (Background)").setDefaultFilename("dirt-background.png")
 				.setNaturalSurface(true).setDestructible(false));
 
 
 		registerTile((new TileSolid(Tiles.ROCK)).setDisplayName("Rock").setDefaultFilename("rock.png")
-				.setNaturalSurface(true).setDestructible(true).setDamagedTile(Tiles.ROCK_DAMAGED)
+				.setNaturalSurface(true).setDestructible(true).setDamagedTile(Tiles.ROCK)
 				.setBackgroundTile(Tiles.ROCK_BACKGROUND));
 		registerTile((new TileSolid(Tiles.ROCK_DAMAGED)).setDisplayName("Rock (Damaged)").setDefaultFilename("rock-damaged.png")
-				.setNaturalSurface(true).setDestructible(true).setDamagedTile(Tiles.ROCK_DAMAGED)
+				.setNaturalSurface(true).setDestructible(true).setDamagedTile(Tiles.ROCK)
 				.setBackgroundTile(Tiles.ROCK_BACKGROUND));
 		registerTile((new TileScenery(Tiles.ROCK_BACKGROUND)).setDisplayName("Rock (Background)").setDefaultFilename("rock-background.png")
 				.setNaturalSurface(true).setDestructible(false));
@@ -83,28 +83,28 @@ public abstract class TileInfo {
 
 
 		registerTile((new TileSolid(Tiles.GRASS)).setDisplayName("Grass").setDefaultFilename("grass.png")
-				.setNaturalSurface(true).setDestructible(true).setDamagedTile(Tiles.GRASS_DAMAGED)
+				.setNaturalSurface(true).setDestructible(true).setDamagedTile(Tiles.GRASS)
 				.setBackgroundTile(Tiles.DIRT_BACKGROUND));
 		registerTile((new TileSolid(Tiles.GRASS_DAMAGED)).setDisplayName("Grass (Damaged)").setDefaultFilename("grass-damaged.png")
-				.setNaturalSurface(true).setDestructible(true).setDamagedTile(Tiles.GRASS_DAMAGED)
+				.setNaturalSurface(true).setDestructible(true).setDamagedTile(Tiles.GRASS)
 				.setBackgroundTile(Tiles.DIRT_BACKGROUND));
 
 
 		registerTile((new TileSolid(Tiles.SAND)).setDisplayName("Sand").setDefaultFilename("sand.png")
-				.setNaturalSurface(true).setDestructible(true).setDamagedTile(Tiles.SAND_DAMAGED)
+				.setNaturalSurface(true).setDestructible(true).setDamagedTile(Tiles.SAND)
 				.setBackgroundTile(Tiles.SAND_BACKGROUND));
 		registerTile((new TileSolid(Tiles.SAND_DAMAGED)).setDisplayName("Sand (Damaged)").setDefaultFilename("sand-damaged.png")
-				.setNaturalSurface(true).setDestructible(true).setDamagedTile(Tiles.SAND_DAMAGED)
+				.setNaturalSurface(true).setDestructible(true).setDamagedTile(Tiles.SAND)
 				.setBackgroundTile(Tiles.SAND_BACKGROUND));
 		registerTile((new TileScenery(Tiles.SAND_BACKGROUND)).setDisplayName("Sand (Background)").setDefaultFilename("sand-background.png")
 				.setNaturalSurface(true).setDestructible(false));
 
 
 		registerTile((new TileSolid(Tiles.SNOW)).setDisplayName("Snow").setDefaultFilename("snow.png")
-				.setNaturalSurface(true).setDestructible(true).setDamagedTile(Tiles.SNOW_DAMAGED)
+				.setNaturalSurface(true).setDestructible(true).setDamagedTile(Tiles.SNOW)
 				.setBackgroundTile(Tiles.SNOW_BACKGROUND));
 		registerTile((new TileSolid(Tiles.SNOW_DAMAGED)).setDisplayName("Snow (Damaged)").setDefaultFilename("snow-damaged.png")
-				.setNaturalSurface(true).setDestructible(true).setDamagedTile(Tiles.SNOW_DAMAGED)
+				.setNaturalSurface(true).setDestructible(true).setDamagedTile(Tiles.SNOW)
 				.setBackgroundTile(Tiles.SNOW_BACKGROUND));
 		registerTile((new TileScenery(Tiles.SNOW_BACKGROUND)).setDisplayName("Snow (Background)").setDefaultFilename("snow-background.png")
 				.setNaturalSurface(true).setDestructible(false));

--- a/coaster/src/test/java/uq/deco2800/coaster/game/TerrainDestructionTest.java
+++ b/coaster/src/test/java/uq/deco2800/coaster/game/TerrainDestructionTest.java
@@ -62,8 +62,7 @@ public class TerrainDestructionTest {
 		Tile tile = world.getTiles().get(tileX, tileY);
 		tile.setHitPoints(3);
 		TerrainDestruction.damageBlock(tileX, tileY, 0, false, true);
-		assertEquals("Ensure tile has switched to damaged variant", tile.getTileType().getType(), Tiles.DIRT_DAMAGED);
-
+		assertEquals("Ensure tile has switched to damaged variant", tile.getTileType().getType(), Tiles.DIRT);
 	}
 
 	@Test


### PR DESCRIPTION
They didn't really fit the aesthetics of the game, so damaged tiles have been temporarily replaced with their non-damaged variants.