### PR TITLE
+Added entity layers for rendering

### DIFF
--- a/coaster/src/main/java/uq/deco2800/coaster/game/entities/Decoration.java
+++ b/coaster/src/main/java/uq/deco2800/coaster/game/entities/Decoration.java
@@ -6,11 +6,13 @@ import uq.deco2800.coaster.game.mechanics.BodyPart;
 import uq.deco2800.coaster.game.mechanics.Side;
 import uq.deco2800.coaster.game.tiles.TileInfo;
 import uq.deco2800.coaster.game.world.World;
+import uq.deco2800.coaster.graphics.LayerList;
 import uq.deco2800.coaster.graphics.sprites.Sprite;
 
 public class Decoration extends Entity {
 
 	public Decoration(Sprite sprite) {
+		layer = LayerList.DECORATIONS;
 		setSprite(sprite);
 		setBlocksOtherEntities(false);
 

--- a/coaster/src/main/java/uq/deco2800/coaster/game/entities/Entity.java
+++ b/coaster/src/main/java/uq/deco2800/coaster/game/entities/Entity.java
@@ -14,6 +14,7 @@ import uq.deco2800.coaster.game.tiles.Tile;
 import uq.deco2800.coaster.game.tiles.TileInfo;
 import uq.deco2800.coaster.game.world.Chunk;
 import uq.deco2800.coaster.game.world.World;
+import uq.deco2800.coaster.graphics.LayerList;
 import uq.deco2800.coaster.graphics.Viewport;
 import uq.deco2800.coaster.graphics.sprites.Sprite;
 import uq.deco2800.coaster.graphics.sprites.SpriteList;
@@ -44,6 +45,8 @@ public abstract class Entity {
 	protected boolean strafeActive = false;
 
 	protected int renderFacing = 1;
+
+	protected LayerList layer;
 
 	// For now, coordinate system is top-left just so we don't have to flip it
 	// when rendering. If this turns out
@@ -80,6 +83,7 @@ public abstract class Entity {
 	private List<AABB> checkedTiles = new LinkedList<AABB>();
 
 	public Entity() {
+		layer = LayerList.DEFAULT;
 		this.world = World.getInstance();
 		setCollisionFilter(e -> true);
 	}
@@ -112,6 +116,20 @@ public abstract class Entity {
 	 */
 	public Sprite getSprite() {
 		return this.sprite;
+	}
+	
+	/**
+	 * Set rendering layer
+	 */
+	public void setLayer(LayerList layer) {
+		this.layer = layer;
+	}
+	
+	/**
+	 * Return rendering layer
+	 */
+	public LayerList getLayer() {
+		return layer;
 	}
 
 	/**

--- a/coaster/src/main/java/uq/deco2800/coaster/game/entities/ItemEntity.java
+++ b/coaster/src/main/java/uq/deco2800/coaster/game/entities/ItemEntity.java
@@ -8,6 +8,7 @@ import uq.deco2800.coaster.game.items.Item;
 import uq.deco2800.coaster.game.mechanics.BodyPart;
 import uq.deco2800.coaster.game.mechanics.Side;
 import uq.deco2800.coaster.game.world.World;
+import uq.deco2800.coaster.graphics.LayerList;
 import uq.deco2800.coaster.graphics.notifications.Toaster;
 
 /**
@@ -50,6 +51,7 @@ public class ItemEntity extends Entity {
 	}
 
 	public ItemEntity(Item item, float width, float height) {
+		layer = LayerList.ITEMS;
 		setSprite(item.getSprite());
 		this.item = item;
 		bounds = new AABB(posX, posY, width, height);

--- a/coaster/src/main/java/uq/deco2800/coaster/game/entities/Player.java
+++ b/coaster/src/main/java/uq/deco2800/coaster/game/entities/Player.java
@@ -32,6 +32,7 @@ import uq.deco2800.coaster.game.world.Chunk;
 import uq.deco2800.coaster.game.world.MiniMap;
 import uq.deco2800.coaster.game.world.RoomWorld;
 import uq.deco2800.coaster.game.world.World;
+import uq.deco2800.coaster.graphics.LayerList;
 import uq.deco2800.coaster.graphics.Viewport;
 import uq.deco2800.coaster.graphics.Window;
 import uq.deco2800.coaster.graphics.notifications.IngameText;
@@ -222,6 +223,7 @@ public class Player extends BasicMovingEntity {
 	 * The Player class is the entity controlled by the user.
 	 */
 	public Player() {
+		layer = LayerList.PLAYERS;
 		setCollisionFilter(e -> this.knockBackTimer < 0);
 
 		sprites.put(EntityState.STANDING, new Sprite(SpriteList.KNIGHT_STANDING));

--- a/coaster/src/main/java/uq/deco2800/coaster/game/entities/PlayerMulti.java
+++ b/coaster/src/main/java/uq/deco2800/coaster/game/entities/PlayerMulti.java
@@ -11,6 +11,7 @@ import uq.deco2800.coaster.game.entities.particles.Particle;
 import uq.deco2800.coaster.game.items.ItemRegistry;
 import uq.deco2800.coaster.game.items.Weapon;
 import uq.deco2800.coaster.game.mechanics.BodyPart;
+import uq.deco2800.coaster.graphics.LayerList;
 import uq.deco2800.coaster.graphics.Viewport;
 import uq.deco2800.coaster.graphics.Window;
 import uq.deco2800.coaster.graphics.sprites.AngledSpriteRelation;

--- a/coaster/src/main/java/uq/deco2800/coaster/game/entities/PlayerMultiDummy.java
+++ b/coaster/src/main/java/uq/deco2800/coaster/game/entities/PlayerMultiDummy.java
@@ -8,6 +8,7 @@ import uq.deco2800.coaster.core.sound.SoundCache;
 import uq.deco2800.coaster.game.entities.npcs.BaseNPC;
 import uq.deco2800.coaster.game.entities.npcs.companions.CompanionNPC;
 import uq.deco2800.coaster.game.mechanics.BodyPart;
+import uq.deco2800.coaster.graphics.LayerList;
 import uq.deco2800.singularity.common.representations.coaster.state.*;
 
 import java.util.List;

--- a/coaster/src/main/java/uq/deco2800/coaster/game/entities/npcs/BaseNPC.java
+++ b/coaster/src/main/java/uq/deco2800/coaster/game/entities/npcs/BaseNPC.java
@@ -18,6 +18,7 @@ import uq.deco2800.coaster.game.mechanics.BodyPart;
 import uq.deco2800.coaster.game.mechanics.Side;
 import uq.deco2800.coaster.game.tiles.TileInfo;
 import uq.deco2800.coaster.graphics.notifications.IngameText;
+import uq.deco2800.coaster.graphics.LayerList;
 import uq.deco2800.coaster.graphics.Viewport;
 
 /**
@@ -61,6 +62,7 @@ public abstract class BaseNPC extends StateEntity {
 	protected int stateDuration;
 	protected NPCSound soundType;
 	Player target;
+
 	/* Future potential fields to implement */
 	// Weapon currentWeapon; //Change to list of weapons if npc can equip or
 	// hold multiple
@@ -70,7 +72,7 @@ public abstract class BaseNPC extends StateEntity {
 	 * Constructor for BaseNPC
 	 */
 	public BaseNPC() {
-
+		layer = LayerList.NPCS;
 	}
 
 	@Override

--- a/coaster/src/main/java/uq/deco2800/coaster/game/entities/particles/Particle.java
+++ b/coaster/src/main/java/uq/deco2800/coaster/game/entities/particles/Particle.java
@@ -6,6 +6,7 @@ import uq.deco2800.coaster.game.entities.AABB;
 import uq.deco2800.coaster.game.entities.Entity;
 import uq.deco2800.coaster.game.mechanics.BodyPart;
 import uq.deco2800.coaster.game.mechanics.Side;
+import uq.deco2800.coaster.graphics.LayerList;
 import uq.deco2800.coaster.graphics.sprites.Sprite;
 import uq.deco2800.coaster.graphics.sprites.SpriteList;
 
@@ -19,6 +20,7 @@ public class Particle extends Entity {
 
 	public Particle(float velX, float velY, float posX, float posY, int particleID, int decayTicks,
 					boolean gravity, boolean deletable) {
+		layer = LayerList.PARTICLES; 
 		bounds = new AABB(posX, posY, size, size);
 		enableGravity = gravity;
 		this.deletable = deletable;

--- a/coaster/src/main/java/uq/deco2800/coaster/graphics/LayerList.java
+++ b/coaster/src/main/java/uq/deco2800/coaster/graphics/LayerList.java
@@ -1,0 +1,17 @@
+package uq.deco2800.coaster.graphics;
+
+/**
+ * An enum listing all the layers on which entities can be rendered.
+ * NOTE: The order of this enum matters, as the first layer here will be
+ * rendered behind the second layer, and so on.
+ * NOTE: This just applies to entities
+ * @author WilliamHayward
+ */
+public enum LayerList {
+	DEFAULT,
+	DECORATIONS,
+	ITEMS,
+	NPCS,
+	PARTICLES,
+	PLAYERS
+}

--- a/coaster/src/main/java/uq/deco2800/coaster/graphics/screens/GameScreen.java
+++ b/coaster/src/main/java/uq/deco2800/coaster/graphics/screens/GameScreen.java
@@ -25,6 +25,7 @@ import uq.deco2800.coaster.game.mechanics.TimeOfDay;
 import uq.deco2800.coaster.game.tiles.Tiles;
 import uq.deco2800.coaster.game.weather.Lightning;
 import uq.deco2800.coaster.game.world.*;
+import uq.deco2800.coaster.graphics.LayerList;
 import uq.deco2800.coaster.graphics.Viewport;
 import uq.deco2800.coaster.graphics.notifications.IngameText;
 import uq.deco2800.coaster.graphics.sprites.Sprite;
@@ -699,34 +700,44 @@ public class GameScreen extends Screen {
 		float right = viewport.getRight();
 		float top = viewport.getTop();
 		float bottom = viewport.getBottom();
-		Player player = null;
+		Map<LayerList, List<Entity>> layers = new HashMap<>();
+		for (LayerList layer: LayerList.values()) {
+			layers.put(layer, new ArrayList<>());
+		}
 		for (Entity entity : entities) {
-			if (entity instanceof Player) {
-				player = (Player) entity;
-			} else {
-				if (entity.getX() + entity.getWidth() > left && entity.getX() < right
-						&& entity.getY() + entity.getHeight() > top && entity.getY() < bottom) {
-					entity.render(gc, viewport, ms);
+			if (entity.getX() + entity.getWidth() > left && entity.getX() < right
+					&& entity.getY() + entity.getHeight() > top && entity.getY() < bottom) {
+				if (entity.getLayer() == null) {
+					System.exit(0);
 				}
+				layers.get(entity.getLayer()).add(entity);
 			}
 		}
-		if (player != null) { //Render player in front of all entities
-			renderHud(player);
-			player.render(gc, viewport, ms);
-			renderSelectedWeapon(player);
-			if (player.getOnMountStatus()) {
-				player.getMount().render(gc, viewport, ms);
-				;
-			}
-			if (player.getSkillSwap()) {
-				player.setUpdateHud(true);
-				player.setSpellKey(player.getSpellKey2());
-				player.setDrawSKill(player.getDrawSkill2());
-				;
-				player.setSpellKey2("");
-				player.setSkillSwap(false);
-				player.setDrawSKill2(null);
+		
+		for (LayerList layer: LayerList.values()) {
+			List<Entity> layerEntities = layers.get(layer);
+			for (Entity entity: layerEntities) {
+				entity.render(gc, viewport, ms);
+				if (entity instanceof Player) {
+					Player player = (Player) entity;
+					renderHud(player);
+					player.render(gc, viewport, ms);
+					renderSelectedWeapon(player);
+					if (player.getOnMountStatus()) {
+						player.getMount().render(gc, viewport, ms);
+						;
+					}
+					if (player.getSkillSwap()) {
+						player.setUpdateHud(true);
+						player.setSpellKey(player.getSpellKey2());
+						player.setDrawSKill(player.getDrawSkill2());
+						;
+						player.setSpellKey2("");
+						player.setSkillSwap(false);
+						player.setDrawSKill2(null);
 
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Previously, gameScreen would iterate over all the world entities and render the ones in the viewport, except for Player entities which it would save to render after, ensuring they stayed on top.

Now, every entity has a layer variable (defined by LayerList enum). During renderEntities, it divides entities up by that variable and then renders them by order of the LayerList enum.